### PR TITLE
New solution 1

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,25 +1,13 @@
 class Solution:
     def minTaps(self, n: int, ranges: list[int]) -> int:
-        # Create array for max length a tap can reach, intialize at 0
-        # Each index of tapReach will indicate the further position reachable from that position
         tapReach = [0] * (n + 1)
         for x, y in enumerate(ranges):
-            # These 2 lines remove values out of garden bounds
-            left = max(0, x-y)
-            right = min(n, x+y)
-            # Updates furthest reach for the position at the left index -> [0,1] -> [0,2], [2,3] - > [2,5], etc
+            left, right = max(0, x-y), min(n, x+y)
             tapReach[left] = max(tapReach[left], right)
-
-        totalTaps = 0
-        curIndex = 0
-        nextIndex = 0
+        totalTaps = curIndex = nextIndex = 0
         for i in range(n + 1):
-            # if current index has exceeded the furthest possible reach, then the garden is unwaterable
-            if i > nextIndex:
-                return -1
-            # else if the current index has exceed the current reach, then jump to the next highest point
+            if i > nextIndex: return -1
             if i > curIndex:
-                totalTaps += 1
-                curIndex = nextIndex
-                nextIndex = max(nextIndex, tapReach[i])
+                totalTaps += 1; curIndex = nextIndex
+            nextIndex = max(nextIndex, tapReach[i])
         return totalTaps

--- a/main.py
+++ b/main.py
@@ -1,26 +1,25 @@
 class Solution:
     def minTaps(self, n: int, ranges: list[int]) -> int:
-        # since you are sorting by furthest left anyways, why not just convert ranges to actual ranges, then sort it
-        # by the left index, iterate from the left when finding valid taps, break upon first encounter
-        #ranges.sort(key=lambda x: x[1], reverse=True)
-        taps = []
+        # Create array for max length a tap can reach, intialize at 0
+        # Each index of tapReach will indicate the further position reachable from that position
+        tapReach = [0] * (n + 1)
         for x, y in enumerate(ranges):
-            # instead of break, continue, since it is not sorted
-            if y == 0:
-                continue
-            taps.append([x - y, x + y])
-        #msort from left index
-        taps.sort(key=lambda x: x[0])
+            # These 2 lines remove values out of garden bounds
+            left = max(0, x-y)
+            right = min(n, x+y)
+            # Updates furthest reach for the position at the left index -> [0,1] -> [0,2], [2,3] - > [2,5], etc
+            tapReach[left] = max(tapReach[left], right)
+
         totalTaps = 0
-        while n > 0:
-            prevN = n
-            for x in range(len(taps)):
-                if taps[x][1] >= n:
-                    n = taps[x][0]
-                    totalTaps += 1
-                    break
-            # if no tap found, break look
-            if prevN == n:
-                break
-        if n <= 0: return totalTaps
-        return -1
+        curIndex = 0
+        nextIndex = 0
+        for i in range(n + 1):
+            # if current index has exceeded the furthest possible reach, then the garden is unwaterable
+            if i > nextIndex:
+                return -1
+            # else if the current index has exceed the current reach, then jump to the next highest point
+            if i > curIndex:
+                totalTaps += 1
+                curIndex = nextIndex
+                nextIndex = max(nextIndex, tapReach[i])
+        return totalTaps

--- a/main.py
+++ b/main.py
@@ -1,47 +1,26 @@
 class Solution:
     def minTaps(self, n: int, ranges: list[int]) -> int:
-        # Enumerate ranges to keep track of i
-        ranges = list(enumerate(ranges))
-        # Sort by largest range, keep track of i value for range
-        ranges.sort(key=lambda x: x[1], reverse=True)
+        # since you are sorting by furthest left anyways, why not just convert ranges to actual ranges, then sort it
+        # by the left index, iterate from the left when finding valid taps, break upon first encounter
+        #ranges.sort(key=lambda x: x[1], reverse=True)
         taps = []
-        # clean 0 taps out of ranges, process bounds and append to new taps array
-        # x = index, y = value of tap
-        for x, y in ranges:
-            # if value of tap is 0, break, tap is useless, all further taps are useless
+        for x, y in enumerate(ranges):
+            # instead of break, continue, since it is not sorted
             if y == 0:
-                break
-            # else, process ranges
+                continue
             taps.append([x - y, x + y])
-        # Create array for all points of garden
-        #print(ranges)
-        #print(taps)
-        # Check right index overlapping or single on furthest right point, set left index to True
-        # How to iterate through ranges? while garden unwatered -> for x in ranges process bounds
-        # No reason to process bounds multiple times, iterate trhough ranges, create bounds array in same sorting
+        #msort from left index
+        taps.sort(key=lambda x: x[0])
         totalTaps = 0
         while n > 0:
-            # for x in taps, if right range is greater than or equal to n, prevN = n, n = left range, pop x, break
-            furthestLeft = n
-            for x, y in enumerate(taps):
-                if y[1] >= n and y[0] < furthestLeft:
-                    furthestLeft = y[0]
-            if furthestLeft == n: break
-            n = furthestLeft
-            totalTaps += 1
+            prevN = n
+            for x in range(len(taps)):
+                if taps[x][1] >= n:
+                    n = taps[x][0]
+                    totalTaps += 1
+                    break
+            # if no tap found, break look
+            if prevN == n:
+                break
         if n <= 0: return totalTaps
         return -1
-
-test = Solution()
-
-# Should output 1
-print(test.minTaps(5, [3,4,1,1,0,0]))
-
-# Should output -1
-print(test.minTaps(3, [0,0,0,0]))
-
-# Should output 3
-print(test.minTaps(7, [1,2,1,0,2,1,0,1]))
-
-# Should output 3
-print(test.minTaps(17, [0,3,3,2,2,4,2,1,5,1,0,1,2,3,0,3,1,1]))


### PR DESCRIPTION
Redesigned twice, first to a left sorted variant, then to an approach using a largest possible jump from each index array.
Final Solution has been condensed
Runtime Beats - 80.87%
Memory Beats - 56.17%